### PR TITLE
Add exact URLs to whitelist

### DIFF
--- a/background.js
+++ b/background.js
@@ -164,6 +164,8 @@ function getTresspassing(process) {
                 // Process whitelist
                 urls = [];  // Clear urls array for reuse
                 for (let site of result.whitelist) {
+                    urls.push('*://*.' + site);
+                    urls.push('*://' + site);
                     urls.push('*://*.' + site + '/*');
                     urls.push('*://' + site + '/*');
                 }


### PR DESCRIPTION
Right now, if you whitelist a page, you can only do so for "directories" due to the way whitelisted pages are queried.

This works: whitelist `example.com/foo` to allow `example.com/foo/` or `example.com/foo/bar`
This doesn’t work: whitelist `example.com/foo` to allow `example.com/foo` precisely.

This pull request changes this behavior so that the exact URL of the whitelist entry is also unblocked.