### PR TITLE
Remove permissions and tweak the settings panel

### DIFF
--- a/background.js
+++ b/background.js
@@ -136,6 +136,8 @@ function delay(delayTime) {
                         });
                         browser.tabs.onUpdated.removeListener(delayListen);
                     }
+                }, {
+                    urls: [browser.runtime.getURL('pages/delay_page.html')],
                 });
             });
         }

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
         "48": "icons/monastery.svg"
     },
 
-    "permissions": ["<all_urls>", "tabs", "notifications", "storage"],
+    "permissions": ["tabs", "notifications", "storage"],
     "background": {
         "scripts": ["background.js"]
     },

--- a/manifest.json
+++ b/manifest.json
@@ -23,11 +23,9 @@
     "browser_action": {
         "default_icon": "icons/monastery.svg",
         "default_title": "Monastery",
-        "default_popup": "popup/status_panel.html",
-        "browser_style": false
+        "default_popup": "popup/status_panel.html"
     },
     "options_ui": {
-        "page": "options/options.html",
-        "browser_style": false
+        "page": "options/options.html"
     }
 }

--- a/options/delays.js
+++ b/options/delays.js
@@ -3,20 +3,20 @@
 // Load up current state; assume that variables are there
 function loadDelays() {
     browser.storage.sync.get(['delays', 'delayOn']).then(result => {
-        document.querySelector('#delayLength input').value = result.delays;
-        document.querySelector('#delaySwitch input').checked = result.delayOn;
-        document.querySelector('#delayLength input').disabled = !result.delayOn;
+        document.querySelector('#delayLength').value = result.delays;
+        document.querySelector('#delaySwitch').checked = result.delayOn;
+        document.querySelector('#delayLength').disabled = !result.delayOn;
     });
 }
 
 // Rig up checkmark toggling functionality
-document.querySelector('#delaySwitch input').addEventListener('change', event => {
+document.querySelector('#delaySwitch').addEventListener('change', event => {
     browser.storage.sync.set({delayOn: event.target.checked});
     loadDelays();
 });
 
 // Rig up delay length functionality
-document.querySelector('#delayLength input').addEventListener('change', event => {
+document.querySelector('#delayLength').addEventListener('change', event => {
     browser.storage.sync.set({delays: event.target.value});
     loadDelays();
 });

--- a/options/delays.js
+++ b/options/delays.js
@@ -3,7 +3,7 @@
 // Load up current state; assume that variables are there
 function loadDelays() {
     browser.storage.sync.get(['delays', 'delayOn']).then(result => {
-        document.querySelector('#delayLength input').value = result.delays / 60;
+        document.querySelector('#delayLength input').value = result.delays;
         document.querySelector('#delaySwitch input').checked = result.delayOn;
         document.querySelector('#delayLength input').disabled = !result.delayOn;
     });
@@ -17,7 +17,7 @@ document.querySelector('#delaySwitch input').addEventListener('change', event =>
 
 // Rig up delay length functionality
 document.querySelector('#delayLength input').addEventListener('change', event => {
-    browser.storage.sync.set({delays: event.target.value * 60});
+    browser.storage.sync.set({delays: event.target.value});
     loadDelays();
 });
 

--- a/options/notifications.js
+++ b/options/notifications.js
@@ -18,13 +18,20 @@ function loadNotifications() {
 
 // Solely adds another notification nubmer input and span text to the notifications div
 function addNotifyEntry(noteTime) {
+    document.querySelector('#notifyTimes #notifyNone').style.display = 'none';
+
+    var noticeRow = document.createElement('div');
+    noticeRow.classList.add('notifyRow');
+
     var noticeDiv = document.createElement('div');
     noticeDiv.classList.add('notifyTime');
+    noticeRow.appendChild(noticeDiv);
 
     var noticeNode = document.createElement('input');
     noticeNode.setAttribute('type', 'number');
     noticeNode.setAttribute('min', '1');
     noticeNode.setAttribute('value', noteTime);
+    noticeNode.setAttribute('size', '5');
     noticeNode.addEventListener('change', event => saveNotifications());
     noticeDiv.appendChild(noticeNode);
 
@@ -32,7 +39,16 @@ function addNotifyEntry(noteTime) {
     noteText.textContent = 'minutes left';
     noticeDiv.appendChild(noteText);
 
-    document.querySelector('#notifications #notifyTimes').appendChild(noticeDiv);
+    var removeButton = document.createElement('span');
+    removeButton.textContent = '(remove)';
+    removeButton.setAttribute('aria-role', 'button');
+    removeButton.addEventListener('click', event => {
+	document.querySelector('#notifications #notifyTimes').removeChild(noticeRow);
+	saveNotifications();
+    });
+    noticeRow.appendChild(removeButton);
+
+    document.querySelector('#notifications #notifyTimes').appendChild(noticeRow);
 }
 
 // Rig up checkbox functionality
@@ -50,6 +66,10 @@ function saveNotifications() {
     savedTimes = [...savedTimes].filter(time => time >= 1).sort((left, right) => right - left);
     browser.storage.sync.set({notifications: savedTimes});
     console.log(`Saved times at ${savedTimes} minute(s)`);
+
+    if (document.querySelector('#notifyTimes').children.length === 1) {
+	document.querySelector('#notifications #notifyNone').style.display = null;
+    }
 }
 
 function setNotifications(shouldBeEnabled) {
@@ -61,29 +81,19 @@ function setNotifications(shouldBeEnabled) {
     if (shouldBeEnabled) {
         for (let paragraph of document.querySelectorAll('#notifications div span'))
             paragraph.classList.remove('notesDisabled');
-        document.querySelector('#notifications div p').classList.remove('notesDisabled');
     }
     else {
         for (let paragraph of document.querySelectorAll('#notifications div span'))
             paragraph.classList.add('notesDisabled');
-        document.querySelector('#notifications div p').classList.add('notesDisabled');
     }
     browser.storage.sync.set({notifyOn: shouldBeEnabled});
     console.log(`Turned notifications ${(shouldBeEnabled) ? 'on' : 'off'}`);
 }
 
 // Add functionality for the add button
-document.querySelector('#notifications input[value=Add]').addEventListener('click', event => {
+document.querySelector('#notifications input[value="Add Notification"]').addEventListener('click', event => {
     addNotifyEntry(15);
     saveNotifications();
-});
-// Add functionality for the remove button
-document.querySelector('#notifications input[value=Remove]').addEventListener('click', event => {
-    if (document.querySelectorAll('#notifications div div').length > 1) {
-        document.querySelector('#notifications div')
-            .removeChild(document.querySelector('#notifications div div:last-of-type'));
-        saveNotifications();
-    }
 });
 
 document.addEventListener('DOMContentLoaded', event => loadNotifications());

--- a/options/options.css
+++ b/options/options.css
@@ -1,7 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=Fira+Sans');
-* {
-    font-family: "Fira Sans", Arial, sans-serif;
-}
 @keyframes fadeOut {
     from {opacity: 1;}
     to {opacity: 0;}

--- a/options/options.css
+++ b/options/options.css
@@ -23,7 +23,7 @@
     display: flex;
 }
 .sitelistAdd input[type=text] {
-    flex-grow: 1;
+    width: 100%;
 }
 .sitelist .errorField {
     margin-top: 5px;

--- a/options/options.css
+++ b/options/options.css
@@ -42,26 +42,17 @@
 }
 
 /* Blocking Settings */
-#blockTime input, #blockTime p{
-    display: inline;
-}
 #blockTime input {
-    width: 70px;
+    display: inline;
     text-align: center;
 }
-#blockTime #minutes {
-    margin-left: 10px;
-}
 #blockTime div {
-    float: right;
+    text-align: right;
 }
 #blockTime #saveState {
     margin-right: 10px;
-    font-size: 15px;
+    font-size: small;
     font-style: italic;
-}
-#blockTime input[type=submit] {
-    width: 75px;
 }
 #blockTime #saveState.edited {
     color: red;

--- a/options/options.css
+++ b/options/options.css
@@ -1,5 +1,5 @@
 @import url('https://fonts.googleapis.com/css?family=Fira+Sans');
-p, h2, span {
+* {
     font-family: "Fira Sans", Arial, sans-serif;
 }
 @keyframes fadeOut {
@@ -13,16 +13,21 @@ p, h2, span {
     align-items: stretch;
     justify-content: space-around;
 }
-form {
-    display: inline-block;
+
+#settingsFlexer > div {
+    width: 45%;
 }
 
 /* Blacklisted And Whitelisted Settings */
-.sitelist select, .sitelist input[type=text] {
-    width: 255px;
+.sitelist select {
+    display: inline-block;
+    width: 100%;
 }
-.sitelist input[type=button], .sitelist input[type=submit] {
-    width: 90px;
+.sitelistAdd {
+    display: flex;
+}
+.sitelistAdd input[type=text] {
+    flex-grow: 1;
 }
 .sitelist .errorField {
     margin-top: 5px;
@@ -34,12 +39,10 @@ form {
 }
 
 .infotext {
-    width: 245px;
-    text-align: left;
     border: 2px solid goldenrod;
     border-radius: 5px;
     padding: 3px;
-    font-size: 12px;
+    font-size: small;
 }
 
 /* Blocking Settings */
@@ -76,49 +79,49 @@ form {
 /*#settings #notifications {
     width: 320px;
 }*/
-#notifications input[type=button] {
-    width: 105px;
-    margin-top: 20px;
-}
-#notifications input[type=number] {
-    width: 50px;
-    height: 25px;
-}
-#notifications #checkboxSwitch {
+#notifications #notifySwitchSection {
     display: flex;
+    align-items: flex-start;
 }
-#notifications #checkboxSwitch span {
-    display: block;
-    margin-left: 10px;
+#notifications #notifySwitch {
+    margin-right: 1rem;
+}
+#notifications .notifyRow {
+    display: flex;
+    padding: 10px 0 10px;
+    justify-content: space-between;
+    margin-left: 1rem;
+    align-items: center;
 }
 #notifications .notifyTime {
-    padding: 10px 0 10px;
+    display: flex;
+    align-items: center;
 }
 #notifications .notifyTime span {
+    flex-grow: 1;
     margin-left: 10px;
+}
+#notifications .notifyRow span[aria-role=button] {
+    cursor: pointer;
+    color: dimgray;
+    text-decoration: none;
+    font-size: small;
 }
 #notifications .notesDisabled {
     color: gray;
 }
 
 /* Delay Settings */
-#delays input[type=button] {
-    width: 105px;
-    margin-top: 20px;
+#delays #delaySwitchSection {
+    display: flex;
+    align-items: flex-start;
+}
+#delays #delaySwitch {
+    margin-right: 1rem;
 }
 #delays input[type=number] {
     width: 60px;
     height: 25px;
-}
-#delays #delaySwitch {
-    display: flex;
-}
-#delays #delaySwitch span {
-    display: block;
-    margin-left: 10px;
-}
-#delays #delayLength span {
-    margin-left: 10px;
 }
 #delays .delayDisabled {
     color: gray;

--- a/options/options.html
+++ b/options/options.html
@@ -88,8 +88,8 @@
                     </div>
                     <div id="delayLength">
                         <p>Delay for:</p>
-                        <input type="number" min=".5" step=".5">
-                        <span>minutes</span>
+                        <input type="number" min="5" step="5">
+                        <span>seconds</span>
                     </div>
                 </form>
             </div>

--- a/options/options.html
+++ b/options/options.html
@@ -15,8 +15,7 @@
                         <select multiple></select>
                         <input type="button" value="Remove">
                     </div>
-                    <br>
-                    <div>
+                    <div class="sitelistAdd">
                         <input type="text" placeholder="Add to blacklist..." autocomplete="off">
                         <input type="submit" value="Add">
                     </div>
@@ -29,12 +28,11 @@
                         <input type="button" value="Remove">
                     </div>
                     <p class="infotext">
-                        Copy your URL carefully!<br />
-                        Firefox is case sensitive.<br />
-                        <i>reddit.com/r/Overwatch might work while<br />
-                        reddit.com/r/overwatch might not</i>
+                        Copy your URL carefully! Firefox is case sensitive.
+                        '<i>reddit.com/r/Overwatch</i>' might work while
+                        '<i>reddit.com/r/overwatch</i>' might not!
                     </p>
-                    <div>
+                    <div class="sitelistAdd">
                         <input type="text" placeholder="Add to whitelist..." autocomplete="off">
                         <input type="submit" value="Add">
                     </div>
@@ -47,7 +45,6 @@
                     <div id="blockTime">
                         <p>
                             Amount of time permitted to spend
-                            <br />
                             on blacklisted sites per day:
                         </p>
                         <br /><br />
@@ -64,32 +61,29 @@
                 </form>
                 <form id="notifications">
                     <h2>Notification Settings</h2>
-                    <div id="checkboxSwitch">
-                        <input type="checkbox">
-                        <span>
-                            Notify me when I'm<br>
-                            almost out of time
-                        </span>
+                    <div id="notifySwitchSection">
+                        <input type="checkbox" id="notifySwitch">
+                        <label for="notifySwitch">
+                            Notify me when I'm almost out of time
+                        </label>
                     </div>
                     <div id="notifyTimes">
-                        <p>Notify me when there remains:</p>
-                    </div>
-                    <input type="button" value="Add">
-                    <input type="button" value="Remove">
+		        <span id="notifyNone" class="notifyRow">(you won't be notified)</span>
+		    </div>
+                    <input type="button" value="Add Notification">
                 </form>
                 <form id="delays">
-                    <h2>Delay Page Settings</h2>
-                    <div id="delaySwitch">
-                        <input type="checkbox">
-                        <span>
-                            Delay access to a page<br>
-                            when I navigate to it
-                        </span>
+                    <h2>Delay Settings</h2>
+                    <div id="delaySwitchSection">
+                        <input type="checkbox" id="delaySwitch">
+			<label for="delaySwitch">
+			  Delay access to a blocked page when I navigate to it
+			</label>
                     </div>
-                    <div id="delayLength">
-                        <p>Delay for:</p>
-                        <input type="number" min="5" step="5">
-                        <span>seconds</span>
+                    <p>
+                        Delay for
+                        <input id="delayLength" type="number" min="5" step="5">
+                        seconds
                     </div>
                 </form>
             </div>

--- a/options/options.html
+++ b/options/options.html
@@ -47,14 +47,13 @@
                             Amount of time permitted to spend
                             on blacklisted sites per day:
                         </p>
-                        <br /><br />
-                        <input id="hours" type="number" min="0" max="23">
-                        <p>Hours</p>
-                        <input id="minutes" type="number" min="0" max="59">
-                        <p>Minutes</p>
-                        <br /><br />
+                        <p>
+			    <input id="hours" type="number" min="0" max="23" size="2">
+			    <label for="hours">hours,</label>
+			    <input id="minutes" type="number" min="0" max="59" size="2">
+			    <label for="minutes">minutes</label>
                         <div>
-                            <p id="saveState"></p>
+                            <span id="saveState"></span>
                             <input type="submit" value="Save">
                         </div>
                     </div>

--- a/options/sitelist.js
+++ b/options/sitelist.js
@@ -66,6 +66,13 @@ function updateSitelist(sitelist, modify) {
 function validateList(sitelist, existList, addition) {
     var errorText = '';
 
+    try {
+	var url = new URL(addition);
+	addition = url.host;
+	addition += (url.port ? `:${url.port}` : '');
+	addition += (url.pathname === '/' ? '' : url.pathname);
+    } catch {}
+
     if (addition == '') errorText = 'No site provided.'
     else if (existList.indexOf(addition) != -1)
         errorText = 'Site is already on the list.'

--- a/popup/status_panel.css
+++ b/popup/status_panel.css
@@ -1,10 +1,9 @@
-@import url('https://fonts.googleapis.com/css?family=Open+Sans');
 body {
+    font-family: system-ui, sans-serif;
     background-color: white;
     padding: 5px 10px 5px 10px;
 }
 p {
-    font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-weight: 500;
     font-size: 20px;
     color: #2D2D2D;
@@ -15,7 +14,6 @@ p {
     text-align: center;
 }
 #settings {
-    font-family: "Open Sans", sans-serif;
     cursor: pointer;
     color: #496E94;
     font-size: 10px;


### PR DESCRIPTION
This PR has a few parts:
* Remove the `<all_urls>` permission; this isn't needed, since scripts are only run by Monastery on pages it controls.
* Parse new URLs that are put into a site list, and extract the hostname and pathname. This (maybe?) fixes #21.
* Modify the settings page design to be responsive. I haven't tried it, but this might fix #13, since it definitely works with a full browser window and Firefox's settings panel.
* Keep track of the current delay in seconds in the settings panel. In my opinion, it's more intuitive instead of 0.5 minutes. Plus, something like 7-10 seconds is fine for me, 30s is overkill; now all of those are options!
* Use native fonts in the settings panel instead of Fira Sans and Open Sans. This makes them load faster and avoid calls to Google's servers.
* Make removing notifications easier, by putting the remove button to the right of the entry.
* Move around a few of the elements in the settings panel, see the screenshot below.

Most of these are visible in the following screenshot (Firefox 87 on GNOME, Debian unstable):
![Screenshot of the settings panel with the changes from this pull request applied](https://i.imgur.com/Zba6OQe.png)

If you don't like some of the changes, I can revert them (e.g. if you just want the permission change, I can remove most of the others, since the permission change doesn't fit in with everything else).